### PR TITLE
Update table creation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ create trigger on_auth_user_created
 
 -- Set up table for links
 create table links (
-  id uuid on delete cascade not null primary key,
+  id uuid not null primary key,
   created_at timestamp with time zone,
   user_id uuid references public.profiles,
   url text,
@@ -46,8 +46,8 @@ create table links (
 );
 
 -- Set up table for viewers
-create table links (
-  id uuid on delete cascade not null primary key,
+create table viewers (
+  id uuid not null primary key,
   created_at timestamp with time zone,
   link_id uuid references public.links on delete cascade,
   email text,


### PR DESCRIPTION
While creating **links** table on supabase it showed "Invalid SQL query" error. It was due to the ``on delete cascade`` clause in the primary key ``id`` .  The same error repeated while creating **viewers** table and it's also due to the same reason.

![Screenshot 2023-05-30 at 12 49 04 PM](https://github.com/alanagoyal/docbase/assets/60638195/9444de21-8dde-428d-a75d-b19f6593083e)


I have updated the table creation query for the ``links`` and ``viewers`` table by removing the ``on delete cascade`` clause from the primary key of both the table. I was able to create both the table successfully. I have made the same update on the Readme File


![Screenshot 2023-05-30 at 1 38 07 PM](https://github.com/alanagoyal/docbase/assets/60638195/52ed6b4c-fc96-4fa9-a7b6-676bfaa0fc4a)
